### PR TITLE
Update changeDetector.gd

### DIFF
--- a/src/scripts/changeDetector.gd
+++ b/src/scripts/changeDetector.gd
@@ -53,6 +53,9 @@ func _process(_delta):
 		scene_changed.emit()
 	
 	for node in observed_nodes:
+		# Node was already freed, can't use .erase() on it
+		if not node:
+			continue
 		if not node.is_inside_tree() or not is_instance_valid(node):
 			observed_nodes.erase(node) 
 			continue

--- a/src/scripts/changeDetector.gd
+++ b/src/scripts/changeDetector.gd
@@ -53,10 +53,10 @@ func _process(_delta):
 		scene_changed.emit()
 	
 	for node in observed_nodes:
-		# Node was already freed, can't use .erase() on it
-		if not node:
+		# Node was already freed or about to be freed, and can't use `.erase()` on it. Also when a node is freed, it removes its references from all arrays.
+		if not is_instance_valid(node):
 			continue
-		if not node.is_inside_tree() or not is_instance_valid(node):
+		if not node.is_inside_tree():
 			observed_nodes.erase(node) 
 			continue
 		


### PR DESCRIPTION
Fixed a problem where already freed nodes were trying to be erased from the observed_nodes array or tested for is_inside_tree / is_instance_valid but as the node was already freed none of these methods worked.