### PR TITLE
Fix excessive print statements every frame

### DIFF
--- a/src/scenes/Avatar3D/Avatar3D.gd
+++ b/src/scenes/Avatar3D/Avatar3D.gd
@@ -22,8 +22,7 @@ func _exit_tree() -> void:
 	if not ui: return
 	ui.queue_free()
 
-# Called by GDTDual instead of setting position/rotation directly, so we
-# know when this avatar has an actual transform to display.
+
 func receive_transform(pos: Vector3, rot: Vector3) -> void:
 	position = pos
 	rotation = rot

--- a/src/scenes/Avatar3D/Avatar3D.gd
+++ b/src/scenes/Avatar3D/Avatar3D.gd
@@ -10,6 +10,7 @@ const MATERIAL: StandardMaterial3D = preload("res://addons/GodotTogether/src/sce
 
 var id := -1
 var main: GodotTogether
+var received_update := false
 
 func _ready() -> void:
 	if not main: return
@@ -20,13 +21,42 @@ func _ready() -> void:
 func _exit_tree() -> void:
 	if not ui: return
 	ui.queue_free()
-	
+
+# Called by GDTDual instead of setting position/rotation directly, so we
+# know when this avatar has an actual transform to display.
+func receive_transform(pos: Vector3, rot: Vector3) -> void:
+	position = pos
+	rotation = rot
+	received_update = true
+
 func _process(delta) -> void:
 	if not main: return
 
+	# Nothing to show yet (avatar still sitting at its default Vector3.ZERO),
+	# and unproject_position() below is not safe to call for a point that
+	# happens to line up with the camera.
+	if not received_update:
+		ui.visible = false
+		return
+
 	var cam = EditorInterface.get_editor_viewport_3d().get_camera_3d()
-	var dist = cam.position.distance_to(position) + 0.05 # Extra distance to prevent division by 0
-	
+	if not cam:
+		ui.visible = false
+		return
+
+	var dist = cam.position.distance_to(position)
+
+	# Camera3D.unproject_position() divides by a projected plane distance
+	# that can be exactly 0 for points that are behind, or extremely close
+	# to, the camera. That's what throws the engine's
+	# "Condition p.d == 0 is true" error. Skip the projection in that case
+	# instead of calling it blindly every frame.
+	if dist < 0.1 or cam.is_position_behind(position):
+		ui.visible = false
+		return
+
+	dist += 0.05 # Extra distance to prevent division by 0
+
 	ui.visible = cam.is_position_in_frustum(position)
 	ui.position = cam.unproject_position(position) - ui.size / 2 - (Vector2(0, 200) / dist)
 

--- a/src/scenes/Avatar3D/Avatar3D.gd
+++ b/src/scenes/Avatar3D/Avatar3D.gd
@@ -46,11 +46,7 @@ func _process(delta) -> void:
 
 	var dist = cam.position.distance_to(position)
 
-	# Camera3D.unproject_position() divides by a projected plane distance
-	# that can be exactly 0 for points that are behind, or extremely close
-	# to, the camera. That's what throws the engine's
-	# "Condition p.d == 0 is true" error. Skip the projection in that case
-	# instead of calling it blindly every frame.
+	# Fix the "Condition p.d == 0 is true" error. 
 	if dist < 0.1 or cam.is_position_behind(position):
 		ui.visible = false
 		return

--- a/src/scripts/net/dual.gd
+++ b/src/scripts/net/dual.gd
@@ -212,5 +212,4 @@ func update_3d_avatar(position: Vector3, rotation: Vector3) -> void:
 	var marker = get_avatar_3d(multiplayer.get_remote_sender_id())
 	if not marker: return
 	
-	marker.position = position
-	marker.rotation = rotation
+	marker.receive_transform(position, rotation)

--- a/src/scripts/sync/node_sync.gd
+++ b/src/scripts/sync/node_sync.gd
@@ -132,8 +132,6 @@ func _check_node(node, root: Node = null) -> void:
 	var new_hashes = get_hash_dict(node)
 	var diff = GDTUtils.compare_dicts(last_hashes, new_hashes)
 	
-	print(diff)
-	
 	if "name" in diff:
 		_node_renamed(node, data["last_path"])
 		data["last_path"] = root.get_path_to(node)


### PR DESCRIPTION
# Description
Fixes two bugs that show up while a multiplayer session is active with the editor's 3D viewport open:

- Removed a leftover debug `print(diff)` in `GDTNodeSync._check_node()` (`node_sync.gd`) that unconditionally printed the result of `GDTUtils.compare_dicts()` on every node-refresh tick (`sync/node_refresh_rate`, default 0.1s), spamming the console with `[]` for every observed node even when nothing had changed. `diff` is now only used for its existing logic (`_node_properties_changed`), never printed.
- Fixed `scene/3d/camera_3d.cpp - Condition "p.d == 0" is true` errors being spammed from `GDTAvatar3D._process()` (`Avatar3D.gd`). The 3D avatar marker calls `Camera3D.unproject_position()` every frame with no guard; a newly created avatar sits at the default `Vector3.ZERO` until the remote user's 3D camera actually moves (since `update_3d_avatar()` intentionally skips sending while at `Vector3.ZERO`), and projecting that point can hit the engine's degenerate `p.d == 0` divide-by-zero case every frame.
  - `GDTAvatar3D` now tracks whether it has received a real transform (`receive_transform()`) and stays hidden until then instead of projecting `Vector3.ZERO`.
  - `_process()` now skips `unproject_position()` (and just hides the marker) when the point is behind the camera or extremely close to it, instead of calling it unconditionally.
  - `GDTDual.update_3d_avatar()` now calls `marker.receive_transform(position, rotation)` instead of setting `.position` / `.rotation` directly, so `GDTAvatar3D` can track initialization.

Changes:
- `src/scripts/sync/node_sync.gd`: removed the debug `print(diff)` call in `_check_node()`
- `src/scenes/Avatar3D/Avatar3D.gd`: added `received_update` flag and `receive_transform()` method; guarded `_process()` against calling `unproject_position()` on an uninitialized/degenerate position
- `src/scripts/net/dual.gd`: `update_3d_avatar()` now calls `marker.receive_transform(position, rotation)` instead of setting properties directly

# Checks
- [ ✔️] I wrote the code myself without significant AI usage
- [✔️] I tested the code manually and ran unit tests which all were successful
- [✔️] I am following the rules in the CONTRIBUTING.md file